### PR TITLE
use reduce instead of a loop (not necessary better)

### DIFF
--- a/js/Jacky.js
+++ b/js/Jacky.js
@@ -24,19 +24,21 @@ var Jacky = {
 function isAReversedSuite(number) {
     return isASuite(number, true)
 }
-        
+
 function isASuite(number, reverse) {
     var asArray = number.toString().split('');
     if (reverse) {
         asArray = asArray.reverse()
     }
-    for(var i = 0; i < asArray.length -1; i++) {
-        if( parseInt(asArray[i]) !=  parseInt(asArray[i +1]) - 1) {
-            return false
-        }
-    }
-   
-    return true
+    var result = asArray.map(
+      function(item){
+        return parseInt(item)
+    }).reduce(
+      function(acc, value) {
+        if(!acc) return false;
+        return (acc + 1 == value) ? value : false
+      })
+    return !!result
 }
 
 function isSingleNumberFllowedBy0s(number) {


### PR DESCRIPTION
J'ai simplement utilisé la fonction reduce au lieu d'une boucle pour l'approche fonctionnel, ça change rien de fondamentale. C'était plus pour l'exercice qu'autre chose.

Sinon j'ai découvert que `[1, 2].map(parseInt)` ne fonctionne pas car `map` a plusieurs arguments tout comme `parseInt` [link](http://stackoverflow.com/questions/262427/javascript-arraymap-and-parseint)

J'utilse [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) qui a donc un accumulateur qui contient false si ce n'est pas une suite ou alors contient la valeur du champ précédent.
Enfin le `return !!result` permet de forcer la dernière valeur à true

Et je pense pas que ça soit plus clair que votre version mais c'était marrant à faire